### PR TITLE
Initialize player with a real piece instead of the all-zero placeholder

### DIFF
--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -34,10 +34,16 @@ export const usePlayer = (): UsePlayerReturn => {
     return piece;
   });
 
-  const [player, setPlayer] = useState<Player>({
-    position: { x: 0, y: 0 },
-    tetromino: TETROMINOS[0].shape,
-    isCollided: false,
+  const [player, setPlayer] = useState<Player>(() => {
+    // Draw the first active piece from the bag initialised above so the player
+    // never holds the all-zero placeholder shape.
+    const [activePiece, newBag] = nextFromBag(bagRef.current);
+    bagRef.current = newBag;
+    return {
+      position: { x: STAGE_WIDTH / 2 - 2, y: 0 },
+      tetromino: activePiece.shape,
+      isCollided: false,
+    };
   });
 
   const updatePlayerPosition = useCallback(({ x, y, isCollided = false }: UpdatePositionArgs): void => {


### PR DESCRIPTION
The player was initialised with TETROMINOS[0].shape ([[0]]) as a placeholder pending the first resetPlayer() call. This caused useStage to run the ghost drop loop on every mount with an all-zero tetromino, which (despite the STAGE_HEIGHT cap) resulted in unexpected behaviour and could freeze the browser under certain render-scheduling conditions.

Draw a real tetromino from the 7-bag in the useState lazy initialiser so the player always holds a valid piece from the very first render.

https://claude.ai/code/session_01RFHXAfNuAxpoohj1hzfw87