### PR TITLE
Fix row clearing bug and make mobile layout scroll-free

### DIFF
--- a/src/components/Display/Display.module.css
+++ b/src/components/Display/Display.module.css
@@ -11,6 +11,16 @@
   font-size: 0.7rem;
   letter-spacing: 0.06em;
   white-space: nowrap;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+@media (max-width: 600px) {
+  .display {
+    padding: 6px 7px;
+    font-size: 0.58rem;
+    border-radius: 6px;
+  }
 }
 
 .gameOver {

--- a/src/components/NextPiece/NextPiece.module.css
+++ b/src/components/NextPiece/NextPiece.module.css
@@ -23,3 +23,16 @@
   grid-template-rows: repeat(var(--size), 18px);
   gap: 2px;
 }
+
+@media (max-width: 600px) {
+  .wrapper {
+    padding: 6px 7px;
+    border-radius: 6px;
+  }
+
+  .grid {
+    grid-template-columns: repeat(var(--size), 13px);
+    grid-template-rows: repeat(var(--size), 13px);
+    gap: 1px;
+  }
+}

--- a/src/components/Stage/Stage.module.css
+++ b/src/components/Stage/Stage.module.css
@@ -14,6 +14,19 @@
 
 @media (max-width: 600px) {
   .stage {
-    --board-width: min(86vw, 300px);
+    /* Size the board so it fits the screen HEIGHT (leaves room for controls +
+       padding) while also not exceeding the width available beside the sidebar.
+       Formula: board is 10 cols × 20 rows of square cells.
+         height-fit  = (viewport_h - controls_h - top_padding) / 20 * 10
+         width-fit   = viewport_w - sidebar(90) - gap(8) - padding(16)
+       Take the minimum so it fits both axes. */
+    --board-width: min(
+      calc((100vh - 208px) / 2),
+      calc(100vw - 114px)
+    );
+    --board-width: min(
+      calc((100svh - 208px) / 2),
+      calc(100vw - 114px)
+    );
   }
 }

--- a/src/components/StartButton/StartButton.module.css
+++ b/src/components/StartButton/StartButton.module.css
@@ -26,3 +26,13 @@
   outline: 2px solid #667eea;
   outline-offset: 3px;
 }
+
+@media (max-width: 600px) {
+  .button {
+    padding: 8px 4px;
+    font-size: 0.58rem;
+    white-space: normal;
+    text-align: center;
+    line-height: 1.3;
+  }
+}

--- a/src/components/Tetris/Tetris.module.css
+++ b/src/components/Tetris/Tetris.module.css
@@ -59,27 +59,42 @@
 }
 
 @media (max-width: 600px) {
+  .wrapper {
+    /* Prevent scrolling — everything must fit inside the viewport */
+    height: 100vh;
+    height: 100svh;
+    justify-content: flex-start;
+    overflow: hidden;
+  }
+
   .container {
-    flex-direction: column;
-    align-items: center;
-    padding: 16px 12px 8px;
-    gap: 12px;
+    /* Sidebar left, grid right — side by side */
+    flex-direction: row;
+    align-items: flex-start;
+    padding: 10px 8px 8px;
+    gap: 8px;
     width: 100%;
   }
 
+  /* Pull the sidebar to the left of the grid (it follows Stage in DOM order) */
   .sidebar {
-    width: 100%;
-    max-width: 300px;
-    flex-direction: row;
-    flex-wrap: wrap;
+    order: -1;
+    width: 90px;
+    flex-shrink: 0;
+    flex-direction: column;
     gap: 6px;
-    align-items: stretch;
   }
 
   .stats {
-    flex-direction: row;
-    gap: 6px;
-    flex: 1;
-    min-width: 100%;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .secondaryBtn {
+    padding: 8px 4px;
+    font-size: 0.58rem;
+    white-space: normal;
+    text-align: center;
+    line-height: 1.3;
   }
 }

--- a/src/hooks/useStage.ts
+++ b/src/hooks/useStage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, type Dispatch, type SetStateAction } from 'react';
+import { useState, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 import { createBoard, checkCollision, STAGE_HEIGHT } from '../helpers/gameHelpers';
 import type { Cell, Board, Player } from '../types';
 
@@ -8,69 +8,77 @@ export const useStage = (player: Player, resetPlayer: () => void): UseStageRetur
   const [board, setBoard] = useState<Board>(createBoard());
   const [rowsCleared, setRowsCleared] = useState(0);
 
+  // Mirror board in a ref so the player-effect can read the latest board
+  // without adding `board` to its dependency array (which would cause a loop).
+  // We must NOT call setRowsCleared inside the setBoard functional updater —
+  // that is a side effect in a render-phase function that Strict Mode calls
+  // twice, corrupting the count and causing missed row clears.
+  const boardRef = useRef<Board>(board);
   useEffect(() => {
-    setRowsCleared(0);
+    boardRef.current = board;
+  });
 
-    const sweepRows = (newBoard: Board): Board =>
-      newBoard.reduce<Board>((acc, row) => {
+  useEffect(() => {
+    const sweepRows = (newBoard: Board): [Board, number] => {
+      let count = 0;
+      const swept = newBoard.reduce<Board>((acc, row) => {
         if (row.every((cell) => cell[1] === 'merged')) {
-          setRowsCleared((prev) => prev + 1);
+          count++;
           acc.unshift(Array.from({ length: newBoard[0].length }, (): Cell => [0, 'clear']));
           return acc;
         }
         acc.push(row);
         return acc;
       }, []);
-
-    const updateBoard = (prevBoard: Board): Board => {
-      // Keep only merged (locked) cells; clear everything else (including previous ghost)
-      const newBoard: Board = prevBoard.map((row) =>
-        row.map((cell) => (cell[1] === 'merged' ? cell : [0, 'clear']))
-      );
-
-      // Compute ghost drop distance on the clean board (only merged cells present).
-      // Cap at STAGE_HEIGHT to guard against empty tetrominoes (all-zero shape)
-      // where checkCollision never fires, which would otherwise loop forever.
-      let ghostDrop = 0;
-      while (
-        ghostDrop < STAGE_HEIGHT &&
-        !checkCollision(player, newBoard, { x: 0, y: ghostDrop + 1 })
-      ) ghostDrop++;
-
-      // Paint ghost cells (only on empty cells — merged cells take priority)
-      player.tetromino.forEach((row, y) => {
-        row.forEach((value, x) => {
-          if (value !== 0) {
-            const ghostY = y + player.position.y + ghostDrop;
-            const ghostX = x + player.position.x;
-            if (newBoard[ghostY]?.[ghostX]?.[1] === 'clear') {
-              newBoard[ghostY][ghostX] = [value, 'ghost'];
-            }
-          }
-        });
-      });
-
-      // Paint the active piece on top (overwrites ghost cells where they overlap)
-      player.tetromino.forEach((row, y) => {
-        row.forEach((value, x) => {
-          if (value !== 0) {
-            newBoard[y + player.position.y][x + player.position.x] = [
-              value,
-              player.isCollided ? 'merged' : 'clear',
-            ];
-          }
-        });
-      });
-
-      if (player.isCollided) {
-        return sweepRows(newBoard);
-      }
-      return newBoard;
+      return [swept, count];
     };
 
-    setBoard((prev) => updateBoard(prev));
+    // Build the updated board from the latest committed board (via ref).
+    const newBoard: Board = boardRef.current.map((row) =>
+      row.map((cell) => (cell[1] === 'merged' ? cell : [0, 'clear']))
+    );
+
+    // Ghost drop distance — capped at STAGE_HEIGHT to guard against all-zero
+    // tetrominoes where checkCollision never fires.
+    let ghostDrop = 0;
+    while (
+      ghostDrop < STAGE_HEIGHT &&
+      !checkCollision(player, newBoard, { x: 0, y: ghostDrop + 1 })
+    ) ghostDrop++;
+
+    // Paint ghost cells (only on empty cells — merged cells take priority).
+    player.tetromino.forEach((row, y) => {
+      row.forEach((value, x) => {
+        if (value !== 0) {
+          const ghostY = y + player.position.y + ghostDrop;
+          const ghostX = x + player.position.x;
+          if (newBoard[ghostY]?.[ghostX]?.[1] === 'clear') {
+            newBoard[ghostY][ghostX] = [value, 'ghost'];
+          }
+        }
+      });
+    });
+
+    // Paint the active piece on top (overwrites ghost cells where they overlap).
+    player.tetromino.forEach((row, y) => {
+      row.forEach((value, x) => {
+        if (value !== 0) {
+          newBoard[y + player.position.y][x + player.position.x] = [
+            value,
+            player.isCollided ? 'merged' : 'clear',
+          ];
+        }
+      });
+    });
+
     if (player.isCollided) {
+      const [sweptBoard, count] = sweepRows(newBoard);
+      setBoard(sweptBoard);
+      setRowsCleared(count);
       resetPlayer();
+    } else {
+      setBoard(newBoard);
+      setRowsCleared(0);
     }
   }, [player, resetPlayer]);
 


### PR DESCRIPTION
Row clearing bug:
  sweepRows was calling setRowsCleared inside the setBoard functional
  updater — a side effect in a render-phase function. React Strict Mode
  calls functional updaters twice, so the count was doubled and the
  cleared-row effect could be skipped. Fixed by mirroring board state in
  a boardRef so the player-effect can compute the new board directly
  (without a functional updater) and call setBoard + setRowsCleared as
  plain state updates outside the render phase.

Mobile layout:
  Previously the sidebar appeared below the grid, requiring vertical
  scroll. New layout: sidebar sits to the LEFT of the grid at all times
  (CSS order: -1 pulls it before the stage). The board is sized so the
  entire game fits within the viewport height with no overflow:
    - height-fit  = (100svh − 208px) / 2  (leaves room for controls)
    - width-fit   = 100vw − 114px          (sidebar + gap + padding)
  Take the minimum of the two so it fits both axes.
  Display, NextPiece, and buttons are made more compact on mobile to
  fit in the 90px-wide sidebar.

https://claude.ai/code/session_01RFHXAfNuAxpoohj1hzfw87